### PR TITLE
Fix kexec-tools build and optimize for size where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
-sudo: false
+dist: xenial
 matrix:
   include:
   - os: linux
-    env: TARGET=x86_64-unknown-linux-musl
 addons:
   apt:
     packages:
+    - musl-dev
     - libpci-dev
     - libusb-dev
     - libusb-1.0-0-dev
+    - uuid-dev
+    - linux-libc-dev
 script:
 - "./build.sh"
 deploy:

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -exu
 
 BASEDIR="${PWD}"
 OUTDIR="${BASEDIR}/build"
@@ -16,6 +16,8 @@ git clone git://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git
 cd kexec-tools
 git checkout -b "${KEXEC_TOOLS_VERSION}"
 ./bootstrap
+# just optimize for space. Kexec uses kernel headers so we cannot use musl-gcc
+# here. See https://wiki.musl-libc.org/faq.html#Q:-Why-am-I-getting- 
 CFLAGS=-Os ./configure
 make
 strip build/sbin/kexec
@@ -27,7 +29,9 @@ cd "${OUTDIR}"
 git clone https://review.coreboot.org/cgit/flashrom.git
 cd flashrom
 git checkout -b "${FLASHROM_VERSION}"
-make
+# no musl-gcc here either, as flashrom needs libpci-dev (we may remove PCI
+# programmers from the build at a later stage though)
+CFLAGS=-Os make
 strip flashrom
 du -hs flashrom
 ldd flashrom
@@ -38,6 +42,6 @@ wget "http://pyropus.ca/software/memtester/old-versions/memtester-${MEMTESTER_VE
 tar xvzf "memtester-${MEMTESTER_VERSION}".tar.gz
 ln -s "memtester-${MEMTESTER_VERSION}" memtester
 cd "memtester-${MEMTESTER_VERSION}"
-make # build statically
+CFLAGS=-Os CC=musl-gcc make # build statically
 du -hs memtester
 ldd memtester


### PR DESCRIPTION
Fixed build after TravisCI platform changes.
* updated distro (explicitly "xenial" as the default has too old package versions)
* removed "sudo: false" which is deprecated
* added a few dependencies explicitly
* building explicitly with musl-gcc where required, and commented where it cannot be used