### PR TITLE
pcitools HWDB detect/set error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ cd "${BUILDDIR}"
 git clone https://github.com/pciutils/pciutils.git
 cd pciutils
 git checkout "${PCIUTILS_VERSION}"
-HWDB=no SHARED=no make
+make HWDB=no SHARED=no
 make install-lib
 
 # build flashrom


### PR DESCRIPTION
HWDB=no SHARED=no are makefile variables and need to be set on the right side of the make command line, not the left side where environment variables are set. 
Fixes HWDB set to "no" but then auto-detected by config and set to "yes".  This isn't seen on the builder because it auto-detects "no" 

```
+ HWDB=no
+ SHARED=no
+ make
cd lib && ./configure
Configuring libpci for your system... x86_64--linux 5.4.0-72-generic x86_64 linux
Looking for access methods... sysfs proc i386-ports dump
Checking for zlib support... yes (auto-detected)
Checking for DNS support... yes (auto-detected)
Checking for libkmod... no (auto-detected)
Checking for udev hwdb support... yes (auto-detected)
Checking whether to build a shared library... no (set manually)
```